### PR TITLE
fix reasoning toggle to show AI reasoning

### DIFF
--- a/app/components/chat/reasoning.tsx
+++ b/app/components/chat/reasoning.tsx
@@ -2,7 +2,7 @@ import { Markdown } from "@/components/prompt-kit/markdown"
 import { cn } from "@/lib/utils"
 import { CaretDownIcon } from "@phosphor-icons/react"
 import { AnimatePresence, motion } from "framer-motion"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 type ReasoningProps = {
   reasoning: string
@@ -19,10 +19,15 @@ export function Reasoning({ reasoning, isStreaming }: ReasoningProps) {
   const [wasStreaming, setWasStreaming] = useState(isStreaming ?? false)
   const [isExpanded, setIsExpanded] = useState(() => isStreaming ?? true)
 
-  if (wasStreaming && isStreaming === false) {
-    setWasStreaming(false)
-    setIsExpanded(false)
-  }
+  useEffect(() => {
+    if (isStreaming) {
+      setWasStreaming(true)
+      setIsExpanded(true)
+    } else if (wasStreaming) {
+      setWasStreaming(false)
+      setIsExpanded(false)
+    }
+  }, [isStreaming, wasStreaming])
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- prevent state updates during render in Reasoning component
- ensure reasoning section expands while streaming and collapses when done

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa55d1aaec8320bf7e7d94b80ae2b0