### PR TITLE
fix reasoning toggle and chat controls

### DIFF
--- a/app/components/chat-input/chat-input.tsx
+++ b/app/components/chat-input/chat-input.tsx
@@ -178,7 +178,10 @@ export function ChatInput({
           />
           <PromptInputActions className="mt-3 w-full justify-between p-2">
             <div className="flex flex-wrap gap-2">
-              <ButtonFileUpload onFileUpload={onFileUpload} model={selectedModel} />
+              <ButtonFileUpload
+                onFileUpload={onFileUpload}
+                model={selectedModel}
+              />
               {hasSearchSupport ? (
                 <ButtonSearch
                   isSelected={enableSearch}
@@ -197,7 +200,10 @@ export function ChatInput({
               <Button
                 size="sm"
                 className="size-9 rounded-full transition-all duration-300 ease-out"
-                disabled={!value || isSubmitting || isOnlyWhitespace(value)}
+                disabled={
+                  status !== "streaming" &&
+                  (!value || isSubmitting || isOnlyWhitespace(value))
+                }
                 type="button"
                 onClick={handleSend}
                 aria-label={status === "streaming" ? "Stop" : "Send message"}

--- a/app/components/chat/message-assistant.tsx
+++ b/app/components/chat/message-assistant.tsx
@@ -1,3 +1,4 @@
+import { Loader } from "@/components/prompt-kit/loader"
 import {
   Message,
   MessageAction,
@@ -9,7 +10,6 @@ import { cn } from "@/lib/utils"
 import type { Message as MessageAISDK } from "@ai-sdk/react"
 import { ArrowClockwise, Check, Copy } from "@phosphor-icons/react"
 import { useCallback, useRef } from "react"
-import { Loader } from "@/components/prompt-kit/loader"
 import { getSources } from "./get-sources"
 import { QuoteButton } from "./quote-button"
 import { Reasoning } from "./reasoning"
@@ -50,8 +50,10 @@ export function MessageAssistant({
   const toolInvocationParts = parts?.filter(
     (part) => part.type === "tool-invocation"
   )
-  const reasoningParts = parts?.find((part) => part.type === "reasoning")
-  const reasoningText = (reasoningParts as any)?.reasoning ?? (reasoningParts as any)?.text
+  const reasoningPart = parts?.find((part) => part.type === "reasoning") as
+    | { reasoning?: string; text?: string }
+    | undefined
+  const reasoningText = reasoningPart?.reasoning ?? reasoningPart?.text ?? ""
   const contentNullOrEmpty = children === null || children === ""
   const isLastStreaming = status === "streaming" && isLast
   const searchImageResults =
@@ -101,7 +103,7 @@ export function MessageAssistant({
         )}
         {...(isQuoteEnabled && { "data-message-id": messageId })}
       >
-        {reasoningText && (
+        {reasoningPart && (
           <Reasoning
             reasoning={reasoningText}
             isStreaming={status === "streaming"}

--- a/app/components/chat/reasoning.tsx
+++ b/app/components/chat/reasoning.tsx
@@ -2,7 +2,7 @@ import { Markdown } from "@/components/prompt-kit/markdown"
 import { cn } from "@/lib/utils"
 import { CaretDownIcon } from "@phosphor-icons/react"
 import { AnimatePresence, motion } from "framer-motion"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 type ReasoningProps = {
   reasoning: string
@@ -19,10 +19,15 @@ export function Reasoning({ reasoning, isStreaming }: ReasoningProps) {
   const [wasStreaming, setWasStreaming] = useState(isStreaming ?? false)
   const [isExpanded, setIsExpanded] = useState(() => isStreaming ?? true)
 
-  if (wasStreaming && isStreaming === false) {
-    setWasStreaming(false)
-    setIsExpanded(false)
-  }
+  useEffect(() => {
+    if (isStreaming) {
+      setWasStreaming(true)
+      setIsExpanded(true)
+    } else if (wasStreaming) {
+      setWasStreaming(false)
+      setIsExpanded(false)
+    }
+  }, [isStreaming, wasStreaming])
 
   return (
     <div>

--- a/app/components/chat/use-chat-core.ts
+++ b/app/components/chat/use-chat-core.ts
@@ -123,6 +123,21 @@ export function useChatCore({
     }
   }, [setMessages, setInput, setFiles, clearDraft])
 
+  // Stop chat streaming when triggered globally
+  useEffect(() => {
+    const handleStop = () => {
+      stop()
+    }
+    if (typeof window !== "undefined") {
+      window.addEventListener("stop-chat", handleStop)
+    }
+    return () => {
+      if (typeof window !== "undefined") {
+        window.removeEventListener("stop-chat", handleStop)
+      }
+    }
+  }, [stop])
+
   // Reset messages when navigating from a chat to home
   useEffect(() => {
     if (
@@ -163,12 +178,12 @@ export function useChatCore({
     try {
       const currentChatId =
         chatId ||
-        (localStorage.getItem("guestChatId") ||
-          (() => {
-            const newId = crypto.randomUUID()
-            localStorage.setItem("guestChatId", newId)
-            return newId
-          })())
+        localStorage.getItem("guestChatId") ||
+        (() => {
+          const newId = crypto.randomUUID()
+          localStorage.setItem("guestChatId", newId)
+          return newId
+        })()
 
       if (input.length > MESSAGE_MAX_LENGTH) {
         toast({
@@ -260,12 +275,12 @@ export function useChatCore({
       try {
         const currentChatId =
           chatId ||
-          (localStorage.getItem("guestChatId") ||
-            (() => {
-              const newId = crypto.randomUUID()
-              localStorage.setItem("guestChatId", newId)
-              return newId
-            })())
+          localStorage.getItem("guestChatId") ||
+          (() => {
+            const newId = crypto.randomUUID()
+            localStorage.setItem("guestChatId", newId)
+            return newId
+          })()
 
         if (!currentChatId) {
           setMessages((prev) => prev.filter((msg) => msg.id !== optimisticId))
@@ -310,12 +325,12 @@ export function useChatCore({
   const handleReload = useCallback(async () => {
     const currentChatId =
       chatId ||
-      (localStorage.getItem("guestChatId") ||
-        (() => {
-          const newId = crypto.randomUUID()
-          localStorage.setItem("guestChatId", newId)
-          return newId
-        })())
+      localStorage.getItem("guestChatId") ||
+      (() => {
+        const newId = crypto.randomUUID()
+        localStorage.setItem("guestChatId", newId)
+        return newId
+      })()
 
     if (!currentChatId) {
       return

--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -1,8 +1,10 @@
 "use client"
+
 import { useChatDraft } from "@/app/hooks/use-chat-draft"
 import { useMessages } from "@/lib/chat-store/messages/provider"
 import Link from "next/link"
 import { DialogPublish } from "./dialog-publish"
+
 export function Header() {
   const user = null
   const { resetMessages } = useMessages()
@@ -23,13 +25,13 @@ export function Header() {
                   resetMessages()
                   clearDraft()
                   if (typeof window !== "undefined") {
+                    window.dispatchEvent(new Event("stop-chat"))
                     window.dispatchEvent(new Event("clear-chat"))
                   }
                 }}
               >
                 <img src="/favicon.ico" alt="Yurie" width={32} height={32} />
               </Link>
-              
             </div>
           </div>
           <div />


### PR DESCRIPTION
## Summary
- ensure reasoning section renders whenever reasoning parts are present
- allow send button to stop streaming even with empty input
- stop streaming and reset messages when clicking the app logo

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa55d1aaec8320bf7e7d94b80ae2b0