### PR TITLE
style: match user bubble text to suggestion hover

### DIFF
--- a/app/components/chat/message-user.tsx
+++ b/app/components/chat/message-user.tsx
@@ -155,7 +155,7 @@ export function MessageUser({
         </div>
       ) : (
         <MessageContent
-          className="bg-accent prose dark:prose-invert relative max-w-[70%] rounded-3xl px-5 py-2.5"
+          className="bg-accent !text-accent-foreground prose dark:prose-invert relative max-w-[70%] rounded-3xl px-5 py-2.5"
           markdown={true}
           ref={contentRef}
           components={{


### PR DESCRIPTION
## Summary
- match user message text color with hover suggestion style

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa5a8e7cd08320bffaee86c7d790b6