### PR TITLE
feat: sync suggestion hover text with message

### DIFF
--- a/components/prompt-kit/prompt-suggestion.tsx
+++ b/components/prompt-kit/prompt-suggestion.tsx
@@ -29,6 +29,7 @@ function PromptSuggestion({
         variant={variant || "outline"}
         size={size || "lg"}
         className={cn("rounded-full", className)}
+        title={content || undefined}
         {...props}
       >
         {children}
@@ -46,6 +47,7 @@ function PromptSuggestion({
           "hover:bg-accent",
           className
         )}
+        title={content || undefined}
         {...props}
       >
         {children}
@@ -67,6 +69,7 @@ function PromptSuggestion({
         "hover:bg-accent",
         className
       )}
+      title={content || undefined}
       {...props}
     >
       {shouldHighlight ? (


### PR DESCRIPTION
## Summary
- show full suggestion text on hover to match chat bubble content

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, unused variables and other pre-existing lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa5ee607cc8320a9a4a25d0fadb61b