### PR TITLE
feat: sync suggestion hover text with message

### DIFF
--- a/components/prompt-kit/prompt-suggestion.tsx
+++ b/components/prompt-kit/prompt-suggestion.tsx
@@ -28,7 +28,12 @@ function PromptSuggestion({
       <Button
         variant={variant || "outline"}
         size={size || "lg"}
-        className={cn("rounded-full", className)}
+        className={cn(
+          "rounded-full",
+          "hover:text-accent-foreground",
+          className
+        )}
+        title={content || undefined}
         {...props}
       >
         {children}
@@ -42,10 +47,11 @@ function PromptSuggestion({
         variant={variant || "ghost"}
         size={size || "sm"}
         className={cn(
-          "w-full justify-start rounded-xl py-2",
-          "hover:bg-accent",
+          "group w-full justify-start rounded-xl py-2",
+          "hover:bg-accent hover:text-accent-foreground",
           className
         )}
+        title={content || undefined}
         {...props}
       >
         {children}
@@ -63,10 +69,11 @@ function PromptSuggestion({
       variant={variant || "ghost"}
       size={size || "sm"}
       className={cn(
-        "w-full justify-start gap-0 rounded-xl py-2",
-        "hover:bg-accent",
+        "group w-full justify-start gap-0 rounded-xl py-2",
+        "hover:bg-accent hover:text-accent-foreground",
         className
       )}
+      title={content || undefined}
       {...props}
     >
       {shouldHighlight ? (
@@ -74,7 +81,7 @@ function PromptSuggestion({
           const index = contentLower.indexOf(highlightLower)
           if (index === -1)
             return (
-              <span className="text-muted-foreground whitespace-pre-wrap">
+              <span className="text-muted-foreground group-hover:!text-accent-foreground whitespace-pre-wrap">
                 {content}
               </span>
             )
@@ -90,15 +97,15 @@ function PromptSuggestion({
           return (
             <>
               {before && (
-                <span className="text-muted-foreground whitespace-pre-wrap">
+                <span className="text-muted-foreground group-hover:!text-accent-foreground whitespace-pre-wrap">
                   {before}
                 </span>
               )}
-              <span className="text-primary font-medium whitespace-pre-wrap">
+              <span className="text-primary font-medium group-hover:!text-accent-foreground whitespace-pre-wrap">
                 {actualHighlightedText}
               </span>
               {after && (
-                <span className="text-muted-foreground whitespace-pre-wrap">
+                <span className="text-muted-foreground group-hover:!text-accent-foreground whitespace-pre-wrap">
                   {after}
                 </span>
               )}
@@ -106,7 +113,7 @@ function PromptSuggestion({
           )
         })()
       ) : (
-        <span className="text-muted-foreground whitespace-pre-wrap">
+        <span className="text-muted-foreground group-hover:!text-accent-foreground whitespace-pre-wrap">
           {content}
         </span>
       )}

--- a/components/prompt-kit/prompt-suggestion.tsx
+++ b/components/prompt-kit/prompt-suggestion.tsx
@@ -101,7 +101,7 @@ function PromptSuggestion({
                   {before}
                 </span>
               )}
-              <span className="text-primary font-medium group-hover:!text-accent-foreground whitespace-pre-wrap">
+              <span className="text-primary group-hover:!text-accent-foreground font-medium whitespace-pre-wrap">
                 {actualHighlightedText}
               </span>
               {after && (

--- a/components/prompt-kit/prompt-suggestion.tsx
+++ b/components/prompt-kit/prompt-suggestion.tsx
@@ -62,7 +62,15 @@ function PromptSuggestion({
   const trimmedHighlight = highlight.trim()
   const contentLower = content.toLowerCase()
   const highlightLower = trimmedHighlight.toLowerCase()
-  const shouldHighlight = contentLower.includes(highlightLower)
+  const index = contentLower.indexOf(highlightLower)
+  const hasMatch = index !== -1
+  const before = hasMatch ? content.substring(0, index) : ""
+  const match = hasMatch
+    ? content.substring(index, index + highlightLower.length)
+    : ""
+  const after = hasMatch
+    ? content.substring(index + highlightLower.length)
+    : ""
 
   return (
     <Button
@@ -76,42 +84,22 @@ function PromptSuggestion({
       title={content || undefined}
       {...props}
     >
-      {shouldHighlight ? (
-        (() => {
-          const index = contentLower.indexOf(highlightLower)
-          if (index === -1)
-            return (
-              <span className="text-muted-foreground group-hover:!text-accent-foreground whitespace-pre-wrap">
-                {content}
-              </span>
-            )
-
-          const actualHighlightedText = content.substring(
-            index,
-            index + highlightLower.length
-          )
-
-          const before = content.substring(0, index)
-          const after = content.substring(index + actualHighlightedText.length)
-
-          return (
-            <>
-              {before && (
-                <span className="text-muted-foreground group-hover:!text-accent-foreground whitespace-pre-wrap">
-                  {before}
-                </span>
-              )}
-              <span className="text-primary group-hover:!text-accent-foreground font-medium whitespace-pre-wrap">
-                {actualHighlightedText}
-              </span>
-              {after && (
-                <span className="text-muted-foreground group-hover:!text-accent-foreground whitespace-pre-wrap">
-                  {after}
-                </span>
-              )}
-            </>
-          )
-        })()
+      {hasMatch ? (
+        <>
+          {before && (
+            <span className="text-muted-foreground group-hover:!text-accent-foreground whitespace-pre-wrap">
+              {before}
+            </span>
+          )}
+          <span className="text-primary font-medium group-hover:!text-accent-foreground whitespace-pre-wrap">
+            {match}
+          </span>
+          {after && (
+            <span className="text-muted-foreground group-hover:!text-accent-foreground whitespace-pre-wrap">
+              {after}
+            </span>
+          )}
+        </>
       ) : (
         <span className="text-muted-foreground group-hover:!text-accent-foreground whitespace-pre-wrap">
           {content}
@@ -122,3 +110,4 @@ function PromptSuggestion({
 }
 
 export { PromptSuggestion }
+


### PR DESCRIPTION
## Summary
- show full suggestion text on hover to match chat bubble content
- match hover text color to user chat bubble for visual consistency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, unused variables, and other pre-existing lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68aa5ee607cc8320a9a4a25d0fadb61b