### PR TITLE
Enable stop during submitted state in chat input

### DIFF
--- a/app/components/chat-input/chat-input.tsx
+++ b/app/components/chat-input/chat-input.tsx
@@ -59,7 +59,7 @@ export function ChatInput({
       return
     }
 
-    if (status === "streaming") {
+    if (status === "streaming" || status === "submitted") {
       stop()
       return
     }
@@ -74,7 +74,7 @@ export function ChatInput({
         return
       }
 
-      if (e.key === "Enter" && status === "streaming") {
+      if (e.key === "Enter" && (status === "streaming" || status === "submitted")) {
         e.preventDefault()
         return
       }
@@ -183,20 +183,25 @@ export function ChatInput({
               />
             </div>
             <PromptInputAction
-              tooltip={status === "streaming" ? "Stop" : "Send"}
+              tooltip={status === "streaming" || status === "submitted" ? "Stop" : "Send"}
             >
               <Button
                 size="sm"
                 className="size-9 rounded-full transition-all duration-300 ease-out"
                 disabled={
                   status !== "streaming" &&
+                  status !== "submitted" &&
                   (!value || isSubmitting || isOnlyWhitespace(value))
                 }
                 type="button"
                 onClick={handleSend}
-                aria-label={status === "streaming" ? "Stop" : "Send message"}
+                aria-label={
+                  status === "streaming" || status === "submitted"
+                    ? "Stop"
+                    : "Send message"
+                }
               >
-                {status === "streaming" ? (
+                {status === "streaming" || status === "submitted" ? (
                   <StopIcon className="size-4" />
                 ) : (
                   <ArrowUpIcon className="size-4" />


### PR DESCRIPTION
## Summary
- handle both `submitted` and `streaming` statuses for the send/stop button
- guard enter key presses while a request is pending

## Testing
- `npm run lint` *(fails: Unused variables and other lint errors in unrelated files)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa6ec62a648320ae44464c0c224f6c