### PR TITLE
Improve default text readability

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -122,7 +122,11 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased leading-relaxed tracking-normal text-pretty;
+  }
+
+  p {
+    @apply leading-relaxed text-pretty;
   }
 }
 


### PR DESCRIPTION
## Summary
- add antialiasing, relaxed line-height, and balanced text wrapping to global body styles
- ensure paragraphs inherit relaxed spacing for easier reading

## Testing
- `npm run lint` *(fails: unexpected any, unused vars, and other existing issues)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa8ae69a848320bae4263c4a85c249