### PR TITLE
feat: add gpt-image-1 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ OPENAI_API_KEY=your_openai_api_key
 - `gpt-5` — highest quality, best reasoning
 - `gpt-5-mini` — balanced quality/speed
 - `gpt-5-nano` — fastest and cheapest
+- `gpt-image-1` — image generation
 
 ## Production Deployment
 

--- a/lib/models/data/openai.ts
+++ b/lib/models/data/openai.ts
@@ -61,6 +61,25 @@ const openaiModels: ModelConfig[] = [
     apiDocs: "https://platform.openai.com/docs/models",
     modelPage: "https://platform.openai.com/docs/models",
   },
+  {
+    id: "gpt-image-1",
+    name: "GPT-Image 1",
+    provider: "OpenAI",
+    providerId: "openai",
+    modelFamily: "GPT-Image",
+    baseProviderId: "openai",
+    description: "Image generation model",
+    tags: ["image", "generation"],
+    vision: true,
+    tools: false,
+    webSearch: false,
+    audio: false,
+    openSource: false,
+    speed: "Medium",
+    website: "https://openai.com",
+    apiDocs: "https://platform.openai.com/docs/models",
+    modelPage: "https://platform.openai.com/docs/models",
+  },
 ]
 
 export { openaiModels }

--- a/lib/openproviders/types.ts
+++ b/lib/openproviders/types.ts
@@ -1,4 +1,8 @@
-export type OpenAIModel = "gpt-5" | "gpt-5-mini" | "gpt-5-nano"
+export type OpenAIModel =
+  | "gpt-5"
+  | "gpt-5-mini"
+  | "gpt-5-nano"
+  | "gpt-image-1"
 
 export type Provider = "openai"
 


### PR DESCRIPTION
## Summary
- add OpenAI `gpt-image-1` configuration
- expose `gpt-image-1` in OpenAI model typings
- document `gpt-image-1` in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa8cb27e088320a8097d79228f4eeb