### PR TITLE
feat: add OpenAI image generation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ OPENAI_API_KEY=your_openai_api_key
 - `gpt-5-nano` — fastest and cheapest
 - `gpt-image-1` — image generation
 
+Use `gpt-image-1` through the `/api/images` endpoint, which calls the OpenAI Images API. It returns a base64-encoded PNG in the `image` field.
+
 ## Production Deployment
 
 ### Deploy to Vercel

--- a/app/api/images/route.ts
+++ b/app/api/images/route.ts
@@ -1,0 +1,67 @@
+import { createErrorResponse } from "../chat/utils";
+
+export const maxDuration = 60;
+
+interface ImageRequest {
+  prompt: string;
+}
+
+export async function POST(req: Request) {
+  try {
+    const { prompt } = (await req.json()) as ImageRequest;
+    if (!prompt) {
+      return new Response(
+        JSON.stringify({ error: "Missing prompt" }),
+        { status: 400 }
+      );
+    }
+
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      console.error("Missing OPENAI_API_KEY in server environment");
+      return new Response(
+        JSON.stringify({
+          error:
+            "Server is not configured with OPENAI_API_KEY. Add it to .env.local and restart.",
+        }),
+        { status: 401, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const response = await fetch("https://api.openai.com/v1/images", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-image-1",
+        prompt,
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(err);
+    }
+
+    const data = await response.json();
+    const image = data.data?.[0]?.b64_json;
+    if (!image) {
+      throw new Error("No image returned from OpenAI");
+    }
+
+    return new Response(JSON.stringify({ image }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("Error in /api/images:", err);
+    const error = err as {
+      code?: string;
+      message?: string;
+      statusCode?: number;
+    };
+    return createErrorResponse(error);
+  }
+}

--- a/lib/openproviders/index.ts
+++ b/lib/openproviders/index.ts
@@ -17,6 +17,11 @@ export function openproviders<T extends SupportedModel>(
   settings?: OpenProvidersOptions<T>,
   apiKey?: string
 ): LanguageModelV1 {
+  if (modelId === ("gpt-image-1" as T)) {
+    throw new Error(
+      "Model gpt-image-1 must be used with the Images API instead of the Responses API"
+    )
+  }
   if (apiKey) {
     const openaiProvider = createOpenAI({
       apiKey,

--- a/lib/openproviders/types.ts
+++ b/lib/openproviders/types.ts
@@ -2,7 +2,6 @@ export type OpenAIModel =
   | "gpt-5"
   | "gpt-5-mini"
   | "gpt-5-nano"
-  | "gpt-image-1"
 
 export type Provider = "openai"
 


### PR DESCRIPTION
## Summary
- guard against using `gpt-image-1` with the Responses API
- expose `/api/images` endpoint for `gpt-image-1` image generation
- document image endpoint in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and unused vars)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa8f4754388320a84fc170b9e9fa75