### PR TITLE
Handle gpt-image-1 requests via Images API

### DIFF
--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -1,2 +1,3 @@
 export const API_ROUTE_CHAT = "/api/chat"
 export const API_ROUTE_CREATE_GUEST = "/api/create-guest"
+export const API_ROUTE_IMAGES = "/api/images"


### PR DESCRIPTION
## Summary
- add `/api/images` route constant
- handle `gpt-image-1` prompts with the Images API and embed resulting image in chat
- avoid reloading when using image model

## Testing
- `npm run lint` *(fails: multiple lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68aa927b93f48320b4b4288056ed7f1f