### PR TITLE
propagate OpenAI error codes

### DIFF
--- a/app/api/images/route.ts
+++ b/app/api/images/route.ts
@@ -45,17 +45,20 @@ export async function POST(req: Request) {
       // useful for clients. Attempt to parse a JSON error message and fall back to
       // a generic one when parsing fails.
       let message: string;
+      let code: string | undefined;
       try {
         const errText = await response.text();
         const parsed = JSON.parse(errText);
         message =
           parsed.error?.message || parsed.message || "Request to OpenAI failed";
+        code = parsed.error?.code;
       } catch {
         message = "Request to OpenAI failed";
       }
 
       return createErrorResponse({
         message,
+        code,
         statusCode: response.status,
       });
     }


### PR DESCRIPTION
## Summary
- parse and return OpenAI error codes in image generation endpoint

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: several lint errors across project)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa98c3b73c8320b9c30a1f9a8f5f1a