### PR TITLE
feat: use responses api for image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ OPENAI_API_KEY=your_openai_api_key
 - `gpt-5` — highest quality, best reasoning
 - `gpt-5-mini` — balanced quality/speed
 - `gpt-5-nano` — fastest and cheapest
-- Image Generation — generate images through the `/api/images` endpoint, which uses the OpenAI Responses API with the image generation tool and returns a base64-encoded PNG in the `image` field.
+- Image Generation — generate images through the `/api/images` endpoint using the OpenAI Responses API's image modality and returning a base64-encoded PNG in the `image` field.
 
 ## Production Deployment
 

--- a/app/api/images/route.ts
+++ b/app/api/images/route.ts
@@ -37,7 +37,7 @@ export async function POST(req: Request) {
       body: JSON.stringify({
         model: "gpt-5",
         input: prompt,
-        tools: [{ type: "image_generation" }],
+        modalities: ["text", "image"],
       }),
     });
 
@@ -66,8 +66,9 @@ export async function POST(req: Request) {
 
     const data = await response.json();
     const image = data.output
-      ?.filter((o: { type: string }) => o.type === "image_generation_call")
-      .map((o: { result: string }) => o.result)[0];
+      ?.find((o: { type: string }) => o.type === "message")
+      ?.content?.find((c: { type: string }) => c.type === "output_image")
+      ?.image_base64;
     if (!image) {
       return createErrorResponse({
         message: "No image returned from OpenAI",


### PR DESCRIPTION
## Summary
- switch image endpoint to use Responses API's image modality instead of the deprecated image generation tool
- document new Responses API usage in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ab3a8cbfb083209e2d219327327f3b