### PR TITLE
Allow rendering images from remote hosts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,10 @@ const nextConfig: NextConfig = withBundleAnalyzer({
         hostname: "www.google.com",
         pathname: "/s2/favicons/**",
       },
+      {
+        protocol: "https",
+        hostname: "**",
+      },
     ],
   },
   eslint: {


### PR DESCRIPTION
## Summary
- allow Next.js Image to load from any remote host by adding wildcard remote pattern

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any / no-unused-vars errors in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68ab5dc1f8948320a172fce63d6e72b5